### PR TITLE
function is bashism

### DIFF
--- a/bin/ginger_phase0.sh
+++ b/bin/ginger_phase0.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Copyright (C) 2018 Itoh Laboratory, Tokyo Institute of Technology
 # 

--- a/bin/ginger_summary.sh
+++ b/bin/ginger_summary.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Copyright (C) 2018 Itoh Laboratory, Tokyo Institute of Technology
 # 


### PR DESCRIPTION
These scripts contain bash style function definition.
So, the shebang directive needs to call bash rather than /bin/sh

The line was changed to be same as ginger_evaluate.sh
