### PR TITLE
Loose run depends

### DIFF
--- a/rattler-build/recipe.yaml
+++ b/rattler-build/recipe.yaml
@@ -39,7 +39,6 @@ requirements:
     - perl-carp
     - perl-pathtools
     - perl-data-dumper 
-    - perl-db_file 
     - perl-findbin 
     - perl-storable 
     - perl-uri 

--- a/rattler-build/recipe.yaml
+++ b/rattler-build/recipe.yaml
@@ -190,7 +190,6 @@ requirements:
     - perl-sub-quote 
     - perl-class-method-modifiers 
     - perl-xsloader 
-    - perl-db-file 
     - perl-parent 
     - perl-constant 
     - htslib ==1.17

--- a/rattler-build/recipe.yaml
+++ b/rattler-build/recipe.yaml
@@ -24,255 +24,246 @@ requirements:
     - git
     - make
 #    - ${{ compiler('cxx') }}
-    - gxx ==13.2.0
-    - libgcc-ng ==13.2.0
+    - gxx >=13.2.0
+    - libgcc-ng 
   run:
-    - perl ==5.26.2 h36c2ea0_1008
-    - python ==3.7.8 h6f2ec95_1_cpython
-    - nextflow ==21.04.0 h4a94de4_0
-    - transdecoder ==5.5.0 pl526_2
-    - matplotlib ==3.5.3 py37h89c1867_2
-    - sra-tools ==3.0.8 h9f5acd7_0
-    - hisat2 ==2.2.1 hdbdd923_6
-    - samtools ==1.9 h10a08f8_12
-    - stringtie ==2.1.7 h978d192_0
-    - perl-carp ==1.38 pl526_3
-    - perl-pathtools ==3.75 pl526h14c3975_1
-    - perl-data-dumper ==2.173 pl526_0
-    - perl-db_file ==1.855 pl5262h7f98852_0
-    - perl-findbin ==1.51 pl526_2
-    - perl-storable ==3.15 pl526h14c3975_0
-    - perl-uri ==1.76 pl526_0
-    - velvet ==1.2.10 he4a0461_6
-    - oases ==0.2.09 h470a237_1
-    - trinity ==2.9.1 h8b12597_0
-    - gmap ==2023.10.01 h9d449c0_0
-    - gffread ==0.12.7 hdcf5f25_3
-    - cd-hit ==4.8.1 h43eeafb_9
-    - seqkit ==2.5.1 h9ee0642_0
-    - perl-exporter ==5.72 pl526_1
-    - gffutils ==0.12 pyh7cba7a3_0
-    - jellyfish ==0.9.0 py37h540881e_1
-    - salmon ==0.14.2 ha0cc327_0
-    - spaln ==2.3.3c pl526he860b03_0
-    - sed ==4.8 he412f7d_0
-    - gcc ==13.2.0 h574f8da_2
-    - augustus ==3.3.2 pl526h985c5e9_2
-    - snap ==2013_11_29 h031d066_6
-    - perl-dbi ==1.642 pl526_0
-    - perl-parallel-forkmanager ==2.02 pl526_0
-    - _libgcc_mutex ==0.1 conda_forge
-    - libstdcxx-ng ==13.2.0 h7e041cc_2
-    - ca-certificates ==2023.7.22 hbcca054_0
-    - python_abi ==3.7 4_cp37m
-    - libgcc-devel_linux-64 ==13.2.0 ha9c7c90_2
+    - perl 
+    - python 
+    - nextflow ==22.10
+    - transdecoder 
+    - matplotlib 
+    - sra-tools
+    - hisat2 ==2.2.1 
+    - samtools ==1.17
+    - stringtie ==2.1.7 
+    - perl-carp
+    - perl-pathtools
+    - perl-data-dumper 
+    - perl-db_file 
+    - perl-findbin 
+    - perl-storable 
+    - perl-uri 
+    - velvet ==1.2.10 
+    - oases ==0.2.09 
+    - trinity 
+    - gmap 
+    - gffread 
+    - cd-hit ==4.8.1 
+    - seqkit 
+    - perl-exporter 
+    - gffutils 
+    - jellyfish 
+    - salmon 
+    - spaln 
+    - sed 
+    - gcc 
+    - augustus==3.5.0 pl5321h816be78_2
+    - snap 
+    - perl-dbi 
+    - perl-parallel-forkmanager 
+    - _libgcc_mutex 
+    - libstdcxx-ng 
+    - ca-certificates 
+    - python_abi 
+    - libgcc-devel_linux-64 
     - ld_impl_linux-64 ==2.40 h41732ed_0
-    - libgfortran4 ==7.5.0 h14aa051_20
-    - libgomp ==13.2.0 h807b86a_2
-    - libgfortran-ng ==7.5.0 h14aa051_20
-    - _openmp_mutex ==4.5 2_gnu
-    - libgcc-ng ==13.2.0 h807b86a_2
-    - graphite2 ==1.3.13 h58526e2_1001
-    - xorg-recordproto ==1.14.2 h7f98852_1002
-    - xorg-inputproto ==2.3.2 h7f98852_1002
-    - xorg-libxdmcp ==1.1.3 h7f98852_0
-    - pthread-stubs ==0.4 h36c2ea0_1001
-    - xorg-xproto ==7.0.31 h7f98852_1007
-    - xorg-kbproto ==1.0.7 h7f98852_1002
-    - xorg-renderproto ==0.11.1 h7f98852_1002
-    - libdb ==6.2.32 h9c3ff4c_0
-    - libev ==4.33 h516909a_1
-    - c-ares ==1.20.1 hd590300_0
+    - libgfortran4 
+    - libgomp
+    - libgfortran-ng 
+    - _openmp_mutex 
+    - libgcc-ng 
+    - graphite2
+    - xorg-recordproto
+    - xorg-inputproto 
+    - xorg-libxdmcp 
+    - pthread-stubs
+    - xorg-xproto 
+    - xorg-kbproto 
+    - xorg-renderproto
+    - libdb 
+    - libev 
+    - c-ares 
     - libbrotlicommon ==1.1.0 hd590300_1
-    - pcre ==8.45 h9c3ff4c_0
-    - gettext ==0.21.1 h27087fc_0
-    - libexpat ==2.5.0 hcb278e6_1
-    - xorg-libxau ==1.0.11 hd590300_0
-    - xorg-xextproto ==7.3.0 h0b41bf4_1003
-    - keyutils ==1.6.1 h166bdaf_0
-    - libuuid ==2.38.1 h0b41bf4_0
-    - xorg-libice ==1.1.1 hd590300_0
-    - pixman ==0.38.0 h516909a_1003
-    - libwebp-base ==1.3.2 hd590300_0
-    - libiconv ==1.17 h166bdaf_0
-    - icu ==58.2 hf484d3e_1000
-    - jpeg ==9e h0b41bf4_3
-    - giflib ==5.2.1 h0b41bf4_3
-    - alsa-lib ==1.2.3.2 h166bdaf_0
-    - openssl ==1.1.1w hd590300_0
-    - libffi ==3.2.1 he1b5a44_1007
-    - gmp ==6.2.1 h58526e2_0
+    - pcre 
+    - gettext 
+    - libexpat 
+    - xorg-libxau 
+    - xorg-xextproto 
+    - keyutils
+    - libuuid 
+    - xorg-libice 
+    - pixman 
+    - libwebp-base 
+    - libiconv 
+    - icu 
+    - jpeg 
+    - giflib 
+    - alsa-lib 
+    - openssl 
+    - libffi 
+    - gmp 
     - metis ==5.1.0 h59595ed_1007
-    - libsanitizer ==13.2.0 h7e041cc_2
+    - libsanitizer 
     - blis ==0.9.0 hd590300_1
-    - openblas ==0.3.3 h9ac9557_1001
+    - openblas 
     - lp_solve ==5.5.2.5 h14c3975_1001
-    - xz ==5.2.6 h166bdaf_0
-    - libdeflate ==1.19 hd590300_0
-    - tbb ==2020.2 h4bd325d_4
-    - bzip2 ==1.0.8 h7f98852_4
-    - ncurses ==6.1 hf484d3e_1002
+    - xz 
+    - libdeflate 
+    - tbb 
+    - bzip2 
+    - ncurses 
     - ossuuid ==1.6.2 hf484d3e_1000
-    - libzlib ==1.2.13 hd590300_5
-    - coreutils ==9.4 hd590300_0
-    - libbrotlienc ==1.1.0 hd590300_1
-    - libbrotlidec ==1.1.0 hd590300_1
-    - expat ==2.5.0 hcb278e6_1
-    - libxcb ==1.15 h0b41bf4_0
+    - libzlib 
+    - expat 
+    - libxcb 
     - xorg-fixesproto ==5.0 h7f98852_1002
-    - xorg-libsm ==1.2.4 h7391055_0
-    - mpfr ==4.2.0 hb012696_0
-    - libblas ==3.9.0 18_linux64_blis
-    - libedit ==3.1.20191231 h46ee950_2
-    - readline ==8.0 h46ee950_1
-    - libssh2 ==1.10.0 haa6b8db_3
-    - libnghttp2 ==1.51.0 hdcd2b5c_0
-    - libpng ==1.6.39 h753d276_0
-    - tk ==8.6.13 h2797004_0
-    - zstd ==1.5.5 hfc55251_0
-    - zlib ==1.2.13 hd590300_5
+    - xorg-libsm 
+    - mpfr 
+    - libblas 
+    - libedit
+    - readline
+    - libssh2 
+    - libnghttp2 
+    - libpng 
+    - tk 
+    - zstd 
+    - zlib 
     - brotli-bin ==1.1.0 hd590300_1
-    - xorg-libx11 ==1.8.6 h8ee46fc_0
-    - liblapack ==3.9.0 3_h893e4fe_netlib
-    - libcblas ==3.9.0 18_linux64_blis
-    - krb5 ==1.20.1 hf9c8cef_0
-    - sqlite ==3.32.3 hcee41ef_1
-    - freetype ==2.12.1 h267a509_2
-    - boost-cpp ==1.68.0 h11c811c_1000
-    - libglib ==2.66.3 hbe7bbb4_0
-    - libtiff ==4.2.0 hf544144_3
-    - libxml2 ==2.9.9 h13577e0_2
-    - brotli ==1.1.0 hd590300_1
-    - xorg-libxrender ==0.9.11 hd590300_0
-    - xorg-libxext ==1.3.4 h0b41bf4_2
-    - xorg-libxfixes ==5.0.3 h7f98852_1004
-    - suitesparse ==5.10.1 hd8046ac_0
-    - gsl ==2.4 h294904e_1006
-    - libcurl ==7.87.0 h6312ad2_0
-    - fontconfig ==2.14.2 h14ed4e7_0
-    - openjpeg ==2.4.0 hb52868f_1
-    - lcms2 ==2.12 hddcbb42_0
-    - xorg-libxi ==1.7.10 h7f98852_0
-    - curl ==7.87.0 h6312ad2_0
-    - xorg-libxtst ==1.2.3 h7f98852_1002
-    - kernel-headers_linux-64 ==2.6.32 he073ed8_16
-    - wheel ==0.41.2 pyhd8ed1ab_0
-    - setuptools ==68.2.2 pyhd8ed1ab_0
-    - sysroot_linux-64 ==2.12 he073ed8_16
-    - pip ==23.2.1 pyhd8ed1ab_0
-    - olefile ==0.46 pyh9f0ad1d_1
-    - munkres ==1.1.4 pyh9f0ad1d_0
-    - zipp ==3.15.0 pyhd8ed1ab_0
-    - typing_extensions ==4.7.1 pyha770c72_0
-    - pyparsing ==3.1.1 pyhd8ed1ab_0
-    - cycler ==0.11.0 pyhd8ed1ab_0
-    - certifi ==2023.7.22 pyhd8ed1ab_0
-    - packaging ==23.2 pyhd8ed1ab_0
-    - six ==1.16.0 pyh6c4a22f_0
-    - argh ==0.29.4 pyhd8ed1ab_0
-    - argcomplete ==3.0.8 pyhd8ed1ab_0
-    - typing-extensions ==4.7.1 hd8ed1ab_0
-    - python-dateutil ==2.8.2 pyhd8ed1ab_0
+    - xorg-libx11 
+    - liblapack 
+    - libcblas 
+    - krb5 
+    - sqlite 
+    - freetype 
+    - boost-cpp 
+    - libglib 
+    - libxml2 
+    - brotli 
+    - xorg-libxrender 
+    - xorg-libxext 
+    - xorg-libxfixes 
+    - suitesparse 
+    - gsl 
+    - libcurl 
+    - fontconfig 
+    - openjpeg 
+    - lcms2 
+    - xorg-libxi 
+    - curl 
+    - xorg-libxtst 
+    - wheel 
+    - setuptools 
+    - sysroot_linux-64 
+    - pip 
+    - olefile 
+    - munkres 
+    - zipp 
+    - pyparsing 
+    - cycler 
+    - certifi 
+    - packaging 
+    - six 
+    - argh 
+    - argcomplete 
+    - python-dateutil 
     - kmer-jellyfish ==2.3.0 h9f5acd7_3
-    - perl-module-load ==0.32 pl526_1
-    - perl-locale-maketext-simple ==0.21 pl526_2
-    - perl-params-check ==0.38 pl526_1
-    - perl-extutils-manifest ==1.72 pl526_0
-    - perl-try-tiny ==0.30 pl526_1
-    - perl-params-util ==1.07 pl526h6bb024c_4
-    - perl-xml-sax-base ==1.09 pl526_0
-    - perl-file-which ==1.23 pl526_0
-    - perl-version ==0.9924 pl526_0
-    - perl-scalar-list-utils ==1.52 pl526h516909a_0
-    - perl-lib ==0.63 pl526_1
-    - perl-extutils-makemaker ==7.36 pl526_1
-    - perl-sub-exporter-progressive ==0.001013 pl526_0
-    - perl-getopt-long ==2.50 pl526_1
-    - perl-sub-identify ==0.14 pl526h14c3975_0
-    - perl-app-cpanminus ==1.7044 pl526_1
-    - perl-base ==2.23 pl526_1
-    - perl-sub-name ==0.21 pl526_1
-    - perl-mro-compat ==0.13 pl526_0
-    - perl-module-runtime ==0.016 pl526_1
-    - perl-sub-quote ==2.006003 pl526_1
-    - perl-class-method-modifiers ==2.12 pl526_0
-    - perl-xsloader ==0.24 pl526_0
-    - perl-db-file ==1.855 pl526h516909a_0
-    - perl-parent ==0.236 pl526_1
-    - perl-constant ==1.33 pl526_1
-    - htslib ==1.9 h244ad75_9
-    - bowtie2 ==2.4.5 py37h1840d8f_3
-    - bowtie ==1.3.1 py37h6add198_3
-    - perl-module-corelist ==5.20190524 pl526_0
-    - perl-text-parsewords ==3.30 pl526_0
-    - perl-devel-globaldestruction ==0.14 pl526_0
-    - perl-package-stash-xs ==0.28 pl526hf484d3e_1
-    - perl-mime-base64 ==3.15 pl526_1
-    - perl-xml-namespacesupport ==1.12 pl526_0
-    - perl-text-abbrev ==1.02 pl526_0
-    - perl-perl-ostype ==1.010 pl526_1
-    - perl-file-util ==4.161950 pl526_3
-    - perl-file-path ==2.16 pl526_0
-    - perl-encode ==2.88 pl526_1
-    - perl-module-metadata ==1.000036 pl526_0
-    - perl-cpan-meta-requirements ==2.140 pl526_0
-    - perl-cpan-meta-yaml ==0.018 pl526_0
-    - perl-eval-closure ==0.14 pl526h6bb024c_4
-    - perl-sub-install ==0.928 pl526_2
-    - perl-module-implementation ==0.09 pl526_2
-    - perl-dist-checkconflicts ==0.11 pl526_2
-    - perl-file-temp ==0.2304 pl526_2
-    - perl-business-isbn-data ==20140910.003 pl526_0
-    - perl-module-load-conditional ==0.68 pl526_2
-    - perl-data-optlist ==0.110 pl526_2
-    - perl-module-runtime-conflicts ==0.003 pl526_0
-    - perl-business-isbn ==3.004 pl526_0
-    - perl-apache-test ==1.40 pl526_1
-    - perl-ipc-cmd ==1.02 pl526_0
-    - perl-sub-exporter ==0.987 pl526_2
-    - perl-package-stash ==0.38 pl526hf484d3e_1
-    - perl-extutils-cbuilder ==0.280230 pl526_1
-    - perl-class-load ==0.25 pl526_0
-    - perl-package-deprecationmanager ==0.17 pl526_0
-    - perl-devel-overloadinfo ==0.005 pl526_0
-    - perl-extutils-parsexs ==3.35 pl526_0
-    - perl-class-load-xs ==0.10 pl526h6bb024c_2
-    - perl-json-pp ==4.04 pl526_0
-    - perl-devel-stacktrace ==2.04 pl526_0
-    - perl-yaml ==1.29 pl526_0
-    - pyvcf3 ==1.0.3 pyhdfd78af_0
-    - perl-role-tiny ==2.000008 pl526_0
-    - perl-xml-sax ==1.02 pl526_0
+    - perl-module-load 
+    - perl-locale-maketext-simple 
+    - perl-params-check 
+    - perl-extutils-manifest 
+    - perl-try-tiny 
+    - perl-params-util 
+    - perl-xml-sax-base 
+    - perl-file-which 
+    - perl-version 
+    - perl-scalar-list-utils 
+    - perl-lib 
+    - perl-extutils-makemaker 
+    - perl-sub-exporter-progressive 
+    - perl-getopt-long 
+    - perl-sub-identify 
+    - perl-app-cpanminus 
+    - perl-base 
+    - perl-sub-name 
+    - perl-mro-compat 
+    - perl-module-runtime 
+    - perl-sub-quote 
+    - perl-class-method-modifiers 
+    - perl-xsloader 
+    - perl-db-file 
+    - perl-parent 
+    - perl-constant 
+    - htslib ==1.17
+    - bowtie2 
+    - bowtie 
+    - perl-module-corelist 
+    - perl-text-parsewords 
+    - perl-devel-globaldestruction 
+    - perl-package-stash-xs 
+    - perl-mime-base64 
+    - perl-xml-namespacesupport 
+    - perl-text-abbrev 
+    - perl-perl-ostype 
+    - perl-file-util 
+    - perl-file-path 
+    - perl-encode 
+    - perl-module-metadata 
+    - perl-cpan-meta-requirements 
+    - perl-cpan-meta-yaml 
+    - perl-eval-closure 
+    - perl-sub-install 
+    - perl-module-implementation 
+    - perl-dist-checkconflicts 
+    - perl-file-temp 
+    - perl-business-isbn-data 
+    - perl-module-load-conditional 
+    - perl-data-optlist 
+    - perl-module-runtime-conflicts 
+    - perl-business-isbn 
+    - perl-apache-test 
+    - perl-ipc-cmd 
+    - perl-sub-exporter 
+    - perl-package-stash 
+    - perl-extutils-cbuilder 
+    - perl-class-load 
+    - perl-package-deprecationmanager 
+    - perl-devel-overloadinfo 
+    - perl-extutils-parsexs 
+    - perl-class-load-xs 
+    - perl-json-pp 
+    - perl-devel-stacktrace 
+    - perl-yaml 
+    - pyvcf3 
+    - perl-role-tiny 
+    - perl-xml-sax 
     - binutils_impl_linux-64 ==2.40 hf600244_0
-    - unicodedata2 ==14.0.0 py37h540881e_1
-    - sip ==4.19.8 py37hf484d3e_1000
-    - glib ==2.66.3 h58526e2_0
-    - tornado ==6.2 py37h540881e_0
-    - numpy ==1.21.6 py37h976b520_0
-    - simplejson ==3.17.6 py37h540881e_1
-    - pillow ==8.2.0 py37h4600e1f_1
-    - importlib-metadata ==4.11.4 py37h89c1867_0
-    - kiwisolver ==1.4.4 py37h7cecad7_0
+    - unicodedata2 
+    - sip 
+    - glib 
+    - tornado ==6.2 
+    - numpy ==1.21.6 
+    - simplejson ==3.17.6
+    - pillow 
+    - importlib-metadata 
+    - kiwisolver ==1.4.4
     - gcc_impl_linux-64 ==13.2.0 h338b0a0_2
-    - fonttools ==4.38.0 py37h540881e_0
+    - fonttools 
     - dbus ==1.13.6 hfdff14a_1
-    - gstreamer ==1.14.5 h36ae1b5_2
-    - cairo ==1.16.0 h18b612c_1001
-    - boost ==1.68.0 py37h8619c78_1001
-    - biopython ==1.79 py37h540881e_2
-    - matplotlib-base ==3.5.3 py37hf395dca_2
-    - gst-plugins-base ==1.14.5 h0935bb2_2
-    - harfbuzz ==2.4.0 h37c48d4_1
-    - qt ==5.9.7 h52cfd70_2
-    - openjdk ==11.0.8 hacce0ff_0
-    - pyqt ==5.9.2 py37hcca6a23_4
-    - perl-cpan-meta ==2.150010 pl526_0
-    - perl-moose ==2.2011 pl526hf484d3e_1
-    - perl-xml-libxml ==2.0132 pl526h7ec2d77_1
-    - perl-module-build ==0.4224 pl526_3
-    - perl-moo ==2.003004 pl526_0
+    - gstreamer 
+    - cairo
+    - boost ==1.74
+    - biopython 
+    - matplotlib-base 
+    - gst-plugins-base 
+    - harfbuzz 
+    - openjdk 
+    - perl-cpan-meta 
+    - perl-moose 
+    - perl-xml-libxml 
+    - perl-module-build 
+    - perl-moo 
     - ncbi-vdb ==3.0.8 hdbdd923_0
-    - pyfaidx ==0.7.2.2 pyhdfd78af_0
+    - pyfaidx 
     - trimmomatic ==0.39 hdfd78af_2
 
 about:


### PR DESCRIPTION
recipe.yml currently specifies very specific versions of run-time dependency. 
While this might be important for reproducibility, the specified combination is not satisfiable with new mini-forge installation anymore.

Here is a loosened recipe, which worked this week. 
Finding a working combination required some trials and I hope this information would benefit you or anyone trying to newly use GINGER. 

version restriction on samtools ==1.17 is for not depending on openssl 1.0 or openssl3, but just openssl 1.1.
nextflow ==22.10 was set as the latest version emitted error on DSL format.
augustus==3.5.0 pl5321h816be78_2 was precisely specified because of boost version dependency (there are different 3.5.0 version depending on different boost versions).

Perhaps, transition to openssl3 will be needed soon, with much effort.
